### PR TITLE
Allow aarch64 programs to be signed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ sbat_data.o : /dev/null
 %.so : %.o
 	$(CC) $(CCLDFLAGS) $(SOFLAGS) -o $@ $^ $(SOLIBS) \
 		$(shell $(CC) -print-libgcc-file-name) \
-		-T $(GNUEFIDIR)/gnuefi/elf_$(ARCH)_efi.lds
+		-T $(TOPDIR)/elf_$(ARCH)_efi.lds
 
 %.o : %.c
 	$(CC) $(BUILDFLAGS) -c -o $@ $^

--- a/elf_aarch64_efi.lds
+++ b/elf_aarch64_efi.lds
@@ -1,0 +1,100 @@
+OUTPUT_FORMAT("elf64-littleaarch64", "elf64-littleaarch64", "elf64-littleaarch64")
+OUTPUT_ARCH(aarch64)
+ENTRY(_start)
+SECTIONS
+{
+  . = 0;
+  ImageBase = .;
+  .hash : { *(.hash) }	/* this MUST come first! */
+  . = ALIGN(4096);
+  .eh_frame :
+  {
+    *(.eh_frame)
+  }
+  . = ALIGN(4096);
+  .text :
+  {
+   _text = .;
+   *(.text)
+   *(.text.*)
+   *(.gnu.linkonce.t.*)
+   _etext = .;
+  }
+  . = ALIGN(4096);
+  .reloc :
+  {
+   *(.reloc)
+  }
+  . = ALIGN(4096);
+  .note.gnu.build-id : {
+    *(.note.gnu.build-id)
+  }
+
+  . = ALIGN(4096);
+  .data.ident : {
+    *(.data.ident)
+  }
+  . = ALIGN(4096);
+  .sbatlevel : {
+    *(.sbatlevel)
+  }
+
+  . = ALIGN(4096);
+  .data :
+  {
+   _data = .;
+   *(.rodata*)
+   *(.got.plt)
+   *(.got)
+   *(.data*)
+   *(.sdata)
+   /* the EFI loader doesn't seem to like a .bss section, so we stick
+      it all into .data: */
+   *(.sbss)
+   *(.scommon)
+   *(.dynbss)
+   *(.bss)
+   *(COMMON)
+   *(.rel.local)
+  }
+
+  . = ALIGN(4096);
+  .vendor_cert :
+  {
+   *(.vendor_cert)
+  }
+  . = ALIGN(4096);
+  .dynamic  : { *(.dynamic) }
+  . = ALIGN(4096);
+  .rela :
+  {
+    *(.rela.data*)
+    *(.rela.got*)
+    *(.rela.stab*)
+  }
+  _edata = .;
+  _data_size = . - _data;
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+  }
+  _esbat = .;
+  _sbat_size = . - _sbat;
+
+  . = ALIGN(4096);
+  .dynsym   : { *(.dynsym) }
+  . = ALIGN(4096);
+  .dynstr   : { *(.dynstr) }
+  . = ALIGN(4096);
+  .ignored.reloc :
+  {
+    *(.rela.reloc)
+    *(.eh_frame)
+    *(.note.GNU-stack)
+  }
+  .comment 0 : { *(.comment) }
+  .note.gnu.build-id : { *(.note.gnu.build-id) }
+}

--- a/elf_arm_efi.lds
+++ b/elf_arm_efi.lds
@@ -1,0 +1,111 @@
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+ENTRY(_start)
+SECTIONS
+{
+  .text 0x0 : {
+    _text = .;
+    *(.text.head)
+    *(.text)
+    *(.text.*)
+    *(.gnu.linkonce.t.*)
+    _evtext = .;
+    . = ALIGN(4096);
+  }
+  _etext = .;
+  _text_size = . - _text;
+  _text_vsize = _evtext - _text;
+
+  . = ALIGN(4096);
+  .data :
+  {
+   _data = .;
+   *(.sdata)
+   *(.data)
+   *(.data1)
+   *(.data.*)
+   *(.got.plt)
+   *(.got)
+
+   *(.dynamic)
+
+   /* the EFI loader doesn't seem to like a .bss section, so we stick
+      it all into .data: */
+   . = ALIGN(16);
+   _bss = .;
+   *(.sbss)
+   *(.scommon)
+   *(.dynbss)
+   *(.bss)
+   *(COMMON)
+   _evdata = .;
+   . = ALIGN(4096);
+   _bss_end = .;
+  }
+  _edata = .;
+  _data_vsize = _evdata - _data;
+  _data_size = . - _data;
+
+  /*
+   * Note that _sbat must be the beginning of the data, and _esbat must be the
+   * end and must be before any section padding.  The sbat self-check uses
+   * _esbat to find the bounds of the data, and if the padding is included, the
+   * CSV parser (correctly) rejects the data as having NUL values in one of the
+   * required columns.
+   */
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+    _esbat = .;
+    . = ALIGN(4096);
+    _epsbat = .;
+  }
+  _sbat_size = _epsbat - _sbat;
+  _sbat_vsize = _esbat - _sbat;
+
+  . = ALIGN(4096);
+  .rodata :
+  {
+    _rodata = .;
+    *(.rodata*)
+    *(.srodata)
+    . = ALIGN(16);
+    *(.note.gnu.build-id)
+    . = ALIGN(4096);
+    *(.vendor_cert)
+    *(.data.ident)
+    . = ALIGN(4096);
+  }
+  . = ALIGN(4096);
+  .rela :
+  {
+    *(.rela.dyn)
+    *(.rela.plt)
+    *(.rela.got)
+    *(.rela.data)
+    *(.rela.data*)
+  }
+  . = ALIGN(4096);
+  .dyn :
+  {
+    *(.dynsym)
+    *(.dynstr)
+    _evrodata = .;
+    . = ALIGN(4096);
+  }
+  _erodata = .;
+  _rodata_size = . - _rodata;
+  _rodata_vsize = _evrodata - _rodata;
+  _alldata_size = . - _data;
+
+  /DISCARD/ :
+  {
+    *(.rel.reloc)
+    *(.eh_frame)
+    *(.note.GNU-stack)
+  }
+  .comment 0 : { *(.comment) }
+}

--- a/elf_ia32_efi.lds
+++ b/elf_ia32_efi.lds
@@ -1,0 +1,99 @@
+OUTPUT_FORMAT("elf32-i386", "elf32-i386", "elf32-i386")
+OUTPUT_ARCH(i386)
+ENTRY(_start)
+SECTIONS
+{
+  . = 0;
+  ImageBase = .;
+  .hash : { *(.hash) }	/* this MUST come first! */
+  . = ALIGN(4096);
+  .text :
+  {
+   _text = .;
+   *(.text)
+   *(.text.*)
+   *(.gnu.linkonce.t.*)
+   _etext = .;
+  }
+  . = ALIGN(4096);
+  .reloc :
+  {
+   *(.reloc)
+  }
+  . = ALIGN(4096);
+  .note.gnu.build-id : {
+    *(.note.gnu.build-id)
+  }
+  . = ALIGN(4096);
+  .data.ident : {
+    *(.data.ident)
+  }
+  . = ALIGN(4096);
+  .sbatlevel : {
+    *(.sbatlevel)
+  }
+
+  . = ALIGN(4096);
+  .data :
+  {
+   _data = .;
+   *(.rodata*)
+   *(.data)
+   *(.data1)
+   *(.data.*)
+   *(.sdata)
+   *(.got.plt)
+   *(.got)
+   /* the EFI loader doesn't seem to like a .bss section, so we stick
+      it all into .data: */
+   *(.sbss)
+   *(.scommon)
+   *(.dynbss)
+   *(.bss)
+   *(COMMON)
+  }
+
+  . = ALIGN(4096);
+  .vendor_cert :
+  {
+   *(.vendor_cert)
+  }
+  . = ALIGN(4096);
+  .dynamic  : { *(.dynamic) }
+  . = ALIGN(4096);
+  .rel :
+  {
+    *(.rel.data)
+    *(.rel.data.*)
+    *(.rel.got)
+    *(.rel.stab)
+    *(.data.rel.ro.local)
+    *(.data.rel.local)
+    *(.data.rel.ro)
+    *(.data.rel*)
+  }
+  _edata = .;
+  _data_size = . - _data;
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+  }
+  _esbat = .;
+  _sbat_size = . - _sbat;
+
+  . = ALIGN(4096);
+  .dynsym   : { *(.dynsym) }
+  . = ALIGN(4096);
+  .dynstr   : { *(.dynstr) }
+  . = ALIGN(4096);
+  /DISCARD/ :
+  {
+    *(.rel.reloc)
+    *(.eh_frame)
+    *(.note.GNU-stack)
+  }
+  .comment 0 : { *(.comment) }
+}

--- a/elf_ia64_efi.lds
+++ b/elf_ia64_efi.lds
@@ -1,0 +1,104 @@
+OUTPUT_FORMAT("elf64-ia64-little")
+OUTPUT_ARCH(ia64)
+ENTRY(_start_plabel)
+SECTIONS
+{
+  . = 0;
+  ImageBase = .;
+  .hash : { *(.hash) }	/* this MUST come first! */
+  . = ALIGN(4096);
+  .text :
+  {
+   _text = .;
+   *(.text)
+   *(.text.*)
+   *(.gnu.linkonce.t.*)
+   _etext = .;
+  }
+  . = ALIGN(4096);
+  __gp = ALIGN (8) + 0x200000;
+  .sdata :
+  {
+   _data = .;
+   *(.got.plt)
+   *(.got)
+   *(.srodata)
+   *(.sdata)
+   *(.sbss)
+   *(.scommon)
+  }
+  . = ALIGN(4096);
+  .note.gnu.build-id : {
+    *(.note.gnu.build-id)
+  }
+  .data.ident : {
+    *(.data.ident)
+  }
+  . = ALIGN(4096);
+  .sbatlevel : {
+    *(.sbatlevel)
+  }
+
+  . = ALIGN(4096);
+  .data :
+  {
+   *(.rodata*)
+   *(.ctors)
+   *(.data*)
+   *(.gnu.linkonce.d*)
+   *(.plabel)	/* data whose relocs we want to ignore */
+   /* the EFI loader doesn't seem to like a .bss section, so we stick
+      it all into .data: */
+   *(.dynbss)
+   *(.bss)
+   *(COMMON)
+  }
+
+  . = ALIGN(4096);
+  .vendor_cert :
+  {
+   *(.vendor_cert)
+  }
+  . = ALIGN(4096);
+  .dynamic  : { *(.dynamic) }
+  . = ALIGN(4096);
+  .rela :
+  {
+    *(.rela.text)
+    *(.rela.data*)
+    *(.rela.sdata)
+    *(.rela.got)
+    *(.rela.gnu.linkonce.d*)
+    *(.rela.stab)
+    *(.rela.ctors)
+  }
+  _edata = .;
+  _data_size = . - _data;
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+  }
+  _esbat = .;
+  _sbat_size = . - _sbat;
+
+  . = ALIGN(4096);
+  .reloc :		/* This is the PECOFF .reloc section! */
+  {
+    *(.reloc)
+  }
+  . = ALIGN(4096);
+  .dynsym   : { *(.dynsym) }
+  . = ALIGN(4096);
+  .dynstr   : { *(.dynstr) }
+  /DISCARD/ :
+  {
+    *(.rela.plabel)
+    *(.rela.reloc)
+    *(.IA_64.unwind*)
+    *(.IA64.unwind*)
+  }
+  .note.gnu.build-id : { *(.note.gnu.build-id) }
+}

--- a/elf_x86_64_efi.lds
+++ b/elf_x86_64_efi.lds
@@ -1,0 +1,101 @@
+/* Same as elf_x86_64_fbsd_efi.lds, except for OUTPUT_FORMAT below - KEEP IN SYNC */
+OUTPUT_FORMAT("elf64-x86-64", "elf64-x86-64", "elf64-x86-64")
+OUTPUT_ARCH(i386:x86-64)
+ENTRY(_start)
+SECTIONS
+{
+  . = 0;
+  ImageBase = .;
+  .hash : { *(.hash) }	/* this MUST come first! */
+  . = ALIGN(4096);
+  .eh_frame :
+  {
+    *(.eh_frame)
+  }
+  . = ALIGN(4096);
+  .text :
+  {
+   _text = .;
+   *(.text)
+   *(.text.*)
+   *(.gnu.linkonce.t.*)
+   _etext = .;
+  }
+  . = ALIGN(4096);
+  .reloc :
+  {
+   *(.reloc)
+  }
+  . = ALIGN(4096);
+  .note.gnu.build-id : {
+    *(.note.gnu.build-id)
+  }
+
+  . = ALIGN(4096);
+  .data.ident : {
+    *(.data.ident)
+  }
+  . = ALIGN(4096);
+  .sbatlevel : {
+    *(.sbatlevel)
+  }
+
+  . = ALIGN(4096);
+  .data :
+  {
+   _data = .;
+   *(.rodata*)
+   *(.got.plt)
+   *(.got)
+   *(.data*)
+   *(.sdata)
+   /* the EFI loader doesn't seem to like a .bss section, so we stick
+      it all into .data: */
+   *(.sbss)
+   *(.scommon)
+   *(.dynbss)
+   *(.bss)
+   *(COMMON)
+   *(.rel.local)
+  }
+
+  . = ALIGN(4096);
+  .vendor_cert :
+  {
+   *(.vendor_cert)
+  }
+  . = ALIGN(4096);
+  .dynamic  : { *(.dynamic) }
+  . = ALIGN(4096);
+  .rela :
+  {
+    *(.rela.data*)
+    *(.rela.got*)
+    *(.rela.stab*)
+  }
+  _edata = .;
+  _data_size = . - _data;
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+  }
+  _esbat = .;
+  _sbat_size = . - _sbat;
+
+  . = ALIGN(4096);
+  .dynsym   : { *(.dynsym) }
+  . = ALIGN(4096);
+  .dynstr   : { *(.dynstr) }
+  . = ALIGN(4096);
+  .ignored.reloc :
+  {
+    *(.rela.reloc)
+    *(.eh_frame)
+    *(.note.GNU-stack)
+  }
+  .comment 0 : { *(.comment) }
+  .note.gnu.build-id : { *(.note.gnu.build-id) }
+}


### PR DESCRIPTION
Currently aarch64 certmule efi programs can not be signed. The header is not correct.

% file certmule.efi
certmule.efi: PE Unknown PE signature 0x742e (stripped to external PDB), for MS Windows

It is missing many fields, including the Subsystem.

% objdump -x certmule.efi

certmule.efi:     file format pei-aarch64-little
certmule.efi
architecture: aarch64, flags 0x00000001:
HAS_RELOC
start address 0x0000000000000000

Characteristics 0x20c
        line numbers stripped
        symbols stripped
        debugging information removed

Time/Date               Wed Dec 31 16:00:00 1969
Magic                   0000
MajorLinkerVersion      0
MinorLinkerVersion      0
SizeOfCode              0000000000000000
SizeOfInitializedData   0000000000000000
SizeOfUninitializedData 0000000000000000
AddressOfEntryPoint     0000000000000000
BaseOfCode              0000000000000000
ImageBase               0000000000000000
SectionAlignment        00000000
FileAlignment           00000000
MajorOSystemVersion     0
MinorOSystemVersion     0
MajorImageVersion       0
MinorImageVersion       0
MajorSubsystemVersion   0
MinorSubsystemVersion   0
Win32Version            00000000
SizeOfImage             00000000
SizeOfHeaders           00000000
CheckSum                00000000
Subsystem               00000000        (unspecified)
DllCharacteristics      00000000
SizeOfStackReserve      0000000000000000
SizeOfStackCommit       0000000000000000
SizeOfHeapReserve       0000000000000000
SizeOfHeapCommit        0000000000000000
LoaderFlags             00000000
NumberOfRvaAndSizes     00000000

Move over all the linker script files from shim to properly build a certmule program that can be signed.

Signed-off-by: Eric Snowberg <eric.snowberg@oracle.com>